### PR TITLE
Fixed Video Recap Typo on production branch

### DIFF
--- a/summit/code/pages/SummitOverviewPage.php
+++ b/summit/code/pages/SummitOverviewPage.php
@@ -339,7 +339,7 @@ class SummitOverviewPage extends SummitPage {
 
         $res = $this->getField('VideoRecapCaption2');
         if(empty($res))
-            return 'October 2014 in Hong Kong.';
+            return 'November 2013 in Hong Kong.';
         return $res;
     }
 


### PR DESCRIPTION
Hello,

Although I modified the source as https://github.com/OpenStackweb/openstack-org/pull/3 , I have found that the production page did not show correct information. I am not sure whether this change would be merged well with your update logistics or not, but please just consider that this change should be reflected to production homepage. 

And also, please change the bug status on launchpad: https://bugs.launchpad.net/openstack-org/+bug/1488826


With many thanks,