### PR TITLE
Updated Interop page with current information.

### DIFF
--- a/themes/openstack/templates/Layout/InteropPage.ss
+++ b/themes/openstack/templates/Layout/InteropPage.ss
@@ -10,7 +10,7 @@
         of that mission is building not only software, but a large OpenStack ecosystem that support its growth and adds
         value to the core technology platform. In carrying out that mission, the OpenStack Foundation has created a set
         of requirements to ensure that the various products and services bearing the OpenStack marks achieve a high level
-        of interoperability. They consist of must-pass tests for required capabilities and designated code.
+        of interoperability. These requirements consist of must-pass tests for required capabilities and designated code.
     </p>
     <p>
         The goal is to help users make informed decisions and adopt the OpenStack products that best meet their business needs.
@@ -20,7 +20,7 @@
     <h3>Overview of &ldquo;OpenStack Powered&rdquo; Marketing Programs</h3>
     <p>
         There are three different trademark licensing programs which apply to products that contain the OpenStack software,
-        all under a unified logo called "OpenStack Powered." Though the programs share a single logo, each of the licensing
+        all under a unified logo called "OpenStack Powered". Though the programs share a single logo, each of the licensing
         programs have a unique list of technical requirements appropriate to their use case, which include required capabilities
         validated by must-pass tests and designated sections of OpenStack software code.
     </p>
@@ -84,7 +84,7 @@
     </div>
     <h3>Qualifying for the OpenStack Powered Marketing Programs</h3>
     <p>OpenStack-based products containing a recent version of the software may qualify for one of the three OpenStack Powered marketing programs, which consist of a logo and unique product naming rights.</p>
-    <p>Products must comply with one of the two most recent versions of requirements approved by the OpenStack Foundation Board of Directors. These versions are numbered based on the date when they were approved, such as &ldquo;2015.07&rdquo; for the version approved in July, 2015.</p>
+    <p>Products must comply with one of the two most recent guidelines approved by the OpenStack Foundation Board of Directors. These versions are numbered based on the date when they were approved, such as &ldquo;2015.07&rdquo; for the version approved in July, 2015.</p>
     <p>The two most recent versions approved by the board are&nbsp;<a title="2015.05 DefCore Capabilities" href="http://git.openstack.org/cgit/openstack/defcore/tree/2015.05.json" target="_blank">2015.05</a>&nbsp;and <a title="Defcore 2015.07 Guideline" href="http://git.openstack.org/cgit/openstack/defcore/tree/2015.07.json">2015.07</a>. The list of required capabilities (with must-pass tests) and designated code sections are published on <a title="OpenStack DefCore Repository" href="http://git.openstack.org/cgit/openstack/defcore/tree/" target="_blank">git.openstack.org</a>&nbsp;and summarized below. Once a company verifies their products include the appropriate designated sections and submit API test results, they will be asked to sign the license agreements.</p>
     <p>You&rsquo;ll note that the &ldquo;Platform&rdquo; program technical requirements are essentially the combination of &ldquo;Compute&rdquo; and &ldquo;Object Storage&rdquo; requirements.</p>
 
@@ -105,15 +105,15 @@
     </p>
     <h3>How to Run the Tests</h3>
     <p>
-        OpenStack interoperability tests are part of the Tempest project suite of tests. To run the tests, you will need
-        to <a href="https://git.openstack.org/cgit/openstack/tempest" target="_blank">install Tempest manually</a> or with
-        some wrapper tool such as the <a href="https://git.openstack.org/cgit/stackforge/refstack-client" target="_blank">RefStack Client</a>.
+        OpenStack interoperability tests are part of the Tempest project suite of tests. To run the tests for your license
+        application, you will need
+        to install <a href="https://git.openstack.org/cgit/openstack/tempest" target="_blank">Tempest</a> with the
+        <a href="https://git.openstack.org/cgit/stackforge/refstack-client" target="_blank">RefStack Client</a>.
         After configuring for your particular product, Tempest can be run with a precompiled inventory of tests available from the Defcore
-        repository. You can use <a href="https://raw.githubusercontent.com/openstack/defcore/tree/2015.04/2015.04.required.txt">this file</a>
-        to configure Tempest test runner to execute only the required tests. We prefer that you run the RefStack Client to produce a JSON file
-        of all tests that have passed. You can email the full json test results file to&nbsp;
-        <a href="mailto:interop@openstack.org">interop@openstack.org</a>&nbsp;or upload the results to the RefStack server and mail
-        the returned test identification link.
+        repository. You can use <a href="https://raw.githubusercontent.com/openstack/defcore/tree/2015.05/2015.05.required.txt">this file</a>
+        to configure Tempest test runner to execute only the required tests. You will need to run Tempest inside of the RefStack Client
+        and upload the results to the RefStack Server. Once your results are uploaded, you can send a link to the report
+        page to <a href="mailto:interop@openstack.org">interop@openstack.org</a>&nbsp.
     </p>
     <p>
         For more detailed instructions to run the tests, please consult


### PR DESCRIPTION
Updated the interop page to clarify which releases are tested
against, and to add that RefStack Client is the only approved
method of submitting test results to the Foundation.