### PR TITLE
Updated Interop page to add "Compatible" driver information

### DIFF
--- a/themes/openstack/templates/Layout/InteropPage.ss
+++ b/themes/openstack/templates/Layout/InteropPage.ss
@@ -7,20 +7,38 @@
 	<h1>OpenStack Interoperability</h1>
     <p>
         OpenStack began with the mission to produce a ubiquitous open source cloud computing platform. A key component
-        of that mission is building not only software, but a large OpenStack ecosystem that support its growth and adds
-        value to the core technology platform. In carrying out that mission, the OpenStack Foundation has created a set
-        of requirements to ensure that the various products and services bearing the OpenStack marks achieve a high level
-        of interoperability. These requirements consist of must-pass tests for required capabilities and designated code.
+        of that mission is building not only software, but a large OpenStack ecosystem that supports its growth and adds
+        value to the core technology platform. In carrying out that mission, the OpenStack Foundation has created, with
+        the community, requirements to ensure that the various products and services bearing the OpenStack marks achieve
+        a high level of interoperability.     
     </p>
     <p>
-        The goal is to help users make informed decisions and adopt the OpenStack products that best meet their business needs.
-        They should be able to easily identify products that meet interoperability requirements via the OpenStack Powered logo,
-        as well as evaluate product capabilities in the OpenStack Marketplace by viewing the test results.
+        The goal is to help users make informed decisions and adopt the OpenStack products that best meet their business
+        needs. They should be able to easily identify products that meet interoperability requirements via the OpenStack
+        logos, as well as evaluate product capabilities in the OpenStack Marketplace by viewing test results and other
+        technical product details.
     </p>
-    <h3>Overview of &ldquo;OpenStack Powered&rdquo; Marketing Programs</h3>
+
+    <h2>Overview of OpenStack Logos</h2>
+    <p>
+        The OpenStack Foundation offers two different logos for vendors. 
+        "<a href="http://www.openstack.org/brand/openstack-powered/">OpenStack Powered</a>" is for products that run fully
+        functional instances of the OpenStack software. Details on the technical and testing requirements to qualify for
+        the "Powered" program are <a href="#openstackpowered">here</a>.
+    </p>
+    <p>
+	   "<a href="http://www.openstack.org/brand/openstack-compatable/">OpenStack Compatible</a>" is for software solutions
+       that interact with "OpenStack Powered" systems, and hardware solutions that are designed to run the OpenStack
+       software. In June 2015, the OpenStack Board approved the development of testing programs for "OpenStack Compatible"
+       products. The OpenStack Foundation is rolling out these testing programs with new requirements for storage drivers
+       starting in November 2015. Network driver testing and application testing requirements are scheduled for 2016.
+       Details on the technical requirements to qualify for the the storage driver "Compatible" logo are
+       <a href="#openstackcompatible">here</a>.
+    </p>
+	<h3 id="openstackpowered">OpenStack Powered</h3>
     <p>
         There are three different trademark licensing programs which apply to products that contain the OpenStack software,
-        all under a unified logo called "OpenStack Powered". Though the programs share a single logo, each of the licensing
+        all under unified "OpenStack Powered" logo. Though the programs share a single logo, each of the licensing
         programs have a unique list of technical requirements appropriate to their use case, which include required capabilities
         validated by must-pass tests and designated sections of OpenStack software code.
     </p>
@@ -82,20 +100,37 @@
             </div>
         </div>
     </div>
-    <h3>Qualifying for the OpenStack Powered Marketing Programs</h3>
-    <p>OpenStack-based products containing a recent version of the software may qualify for one of the three OpenStack Powered marketing programs, which consist of a logo and unique product naming rights.</p>
-    <p>Products must comply with one of the two most recent guidelines approved by the OpenStack Foundation Board of Directors. These versions are numbered based on the date when they were approved, such as &ldquo;2015.07&rdquo; for the version approved in July, 2015.</p>
-    <p>The two most recent versions approved by the board are&nbsp;<a title="2015.05 DefCore Capabilities" href="http://git.openstack.org/cgit/openstack/defcore/tree/2015.05.json" target="_blank">2015.05</a>&nbsp;and <a title="Defcore 2015.07 Guideline" href="http://git.openstack.org/cgit/openstack/defcore/tree/2015.07.json">2015.07</a>. The list of required capabilities (with must-pass tests) and designated code sections are published on <a title="OpenStack DefCore Repository" href="http://git.openstack.org/cgit/openstack/defcore/tree/" target="_blank">git.openstack.org</a>&nbsp;and summarized below. Once a company verifies their products include the appropriate designated sections and submit API test results, they will be asked to sign the license agreements.</p>
-    <p>You&rsquo;ll note that the &ldquo;Platform&rdquo; program technical requirements are essentially the combination of &ldquo;Compute&rdquo; and &ldquo;Object Storage&rdquo; requirements.</p>
 
-    <h3>
+    <h4>Qualifying for the OpenStack Powered Marketing Programs</h4>
+    <p>
+        OpenStack-based products containing a recent version of the software may qualify for one of the three OpenStack
+        Powered marketing programs, which consist of a logo and unique product naming rights.
+    </p>
+    <p>
+        Products must comply with one of the two most recent guidelines approved by the OpenStack Foundation Board of Directors.
+        These versions are numbered based on the date when they were approved, such as "2015.07"for the version approved in July, 2015.
+    </p>
+    <p>
+        The two most recent versions approved by the board are
+        "<a title="2015.05 DefCore Capabilities" href="http://git.openstack.org/cgit/openstack/defcore/tree/2015.05.json" target="_blank">2015.05</a>"
+        and "<a title="Defcore 2015.07 Guideline" href="http://git.openstack.org/cgit/openstack/defcore/tree/2015.07.json">2015.07</a>".
+        The list of required capabilities (with must-pass tests) and designated code sections are published on
+        <a title="OpenStack DefCore Repository" href="http://git.openstack.org/cgit/openstack/defcore/tree/" target="_blank">git.openstack.org</a>&nbsp;
+        and summarized below. Once a company verifies their products include the appropriate designated sections and submit API test results, they will
+        be asked to sign the license agreements.
+    </p>
+    <p>
+        You'll note that the "Platform" program technical requirements are essentially the combination of "Compute" and "Object Storage" requirements.
+    </p>
+
+    <h4>
         Version
         <select id="interop_version">
             <% loop getInteropProgramVersions() %>
             <option value="$ID">$Name</option>
             <% end_loop %>
         </select>
-    </h3>
+    </h4>
 
     $getCapabilitiesTable()
 
@@ -103,7 +138,7 @@
         To apply for one of the OpenStack Powered marketing programs today, please review the requirements and
         <a href="brand/openstack-powered">submit via the online form</a>.
     </p>
-    <h3>How to Run the Tests</h3>
+    <h4>How to Run the Tests</h4>
     <p>
         OpenStack interoperability tests are part of the Tempest project suite of tests. To run the tests for your license
         application, you will need
@@ -121,6 +156,20 @@
         If you need help getting started, contact Chris Hoge, the Foundation's Interop Engineer, by emailing
         <a href="mailto:interop@openstack.org">interop@openstack.org</a>. The Foundation is looking for feedback from companies
         who are running tests in order to improve the testing process and shape policy in the future.
+    </p>
+    <h3 id="openstackcompatible">OpenStack Compatible</h3>
+    <p>
+    	There are two types of "OpenStack Compatible" products that fall under the unified logo program. The first is software
+        applications that interact with "OpenStack Powered" systems. The second is hardware solutions and drivers that run
+        OpenStack software. Starting November 1 2015, The OpenStack Foundation will require that new "OpenStack Compatible" logos
+        for storage drivers pass community-defined third-party integration tests. The Cinder team has a
+        <a href="https://wiki.openstack.org/wiki/Cinder/tested-3rdParty-drivers">detailed overview of the requirements</a> for
+        third-party testing. 
+    </p>
+    <p>
+        Proof of successful third-party testing will be required at the time of licensing, and may include links to Gerrit runs
+        and the Tempest logs of those runs. You can begin the application process by filling out the form at the
+        <a href="http://www.openstack.org/brand/openstack-compatible">"OpenStack Compatible" brand page</a>.
     </p>
 
 	<% if Menu(2) %>


### PR DESCRIPTION
Updated the Interop page to add new information about the
"Compatible" logo licensing changes. New logos for Storage
drivers now require that the drivers pass the third-party
CI testing for Cinder.