### PR TITLE
Default developer.openstack.org link to http

### DIFF
--- a/themes/openstack/templates/Layout/Includes/HomePageBottom.ss
+++ b/themes/openstack/templates/Layout/Includes/HomePageBottom.ss
@@ -8,7 +8,7 @@
                     <h2>
                         Open source software for creating private and public clouds.
                     </h2>
-                    <p>OpenStack software controls large pools of compute, storage, and networking resources throughout a datacenter, managed through a <a href="/software/openstack-dashboard/">dashboard</a> or via the <a href="//developer.openstack.org">OpenStack API</a>. OpenStack works with <a href="//openstack.org/marketplace/drivers/">popular enterprise and open source technologies</a> making it ideal for heterogeneous infrastructure.</p>
+                    <p>OpenStack software controls large pools of compute, storage, and networking resources throughout a datacenter, managed through a <a href="/software/openstack-dashboard/">dashboard</a> or via the <a href="http://developer.openstack.org">OpenStack API</a>. OpenStack works with <a href="//openstack.org/marketplace/drivers/">popular enterprise and open source technologies</a> making it ideal for heterogeneous infrastructure.</p>
 
 					<p><a href="//openstack.org/user-stories/">Hundreds of the world’s largest brands</a> rely on OpenStack to run their businesses every day, reducing costs and helping them move faster. OpenStack has a strong <a href="//openstack.org/foundation/companies/">ecosystem</a>, and users seeking commercial support can choose from different OpenStack-powered products and services in the <a href="//openstack.org/marketplace/">Marketplace.</a></p>
 


### PR DESCRIPTION
developer.openstack.org runs only on http. When www.openstack.org is
visited over https, the link to developer.openstack.org is pointed over
https. This throws an error. Chaning it to default to http.