### PR TITLE
Fix URL to CLA

### DIFF
--- a/summit/templates/PresentationPage.ss
+++ b/summit/templates/PresentationPage.ss
@@ -130,7 +130,7 @@
                         <li><a href="http://openstack.org/brand/">Logos & Guidelines</a></li>
                         <li><a href="http://openstack.org/brand/openstack-trademark-policy/">Trademark Policy</a></li>
                         <li><a href="http://openstack.org/privacy/">Privacy Policy</a></li>
-                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributors_License_Agreement">OpenStack
+                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributor_License_Agreement">OpenStack
                             CLA</a></li>
                     </ul>
                 </div>

--- a/summit/templates/SummitPage.ss
+++ b/summit/templates/SummitPage.ss
@@ -131,7 +131,7 @@
                         <li><a href="http://openstack.org/brand/">Logos & Guidelines</a></li>
                         <li><a href="http://openstack.org/brand/openstack-trademark-policy/">Trademark Policy</a></li>
                         <li><a href="http://openstack.org/privacy/">Privacy Policy</a></li>
-                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributors_License_Agreement">OpenStack CLA</a></li>
+                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributor_License_Agreement">OpenStack CLA</a></li>
                     </ul>
                 </div>
                 <div class="col-lg-4 col-sm-4">

--- a/summit/templates/SummitSecurity.ss
+++ b/summit/templates/SummitSecurity.ss
@@ -83,7 +83,7 @@
                         <li><a href="http://openstack.org/brand/">Logos & Guidelines</a></li>
                         <li><a href="http://openstack.org/brand/openstack-trademark-policy/">Trademark Policy</a></li>
                         <li><a href="http://openstack.org/privacy/">Privacy Policy</a></li>
-                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributors_License_Agreement">OpenStack CLA</a></li>
+                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributor_License_Agreement">OpenStack CLA</a></li>
                     </ul>
                 </div>
                 <div class="col-lg-4 col-sm-4">

--- a/summit/templates/SummitSecurity_login.ss
+++ b/summit/templates/SummitSecurity_login.ss
@@ -82,7 +82,7 @@
                         <li><a href="http://openstack.org/brand/">Logos & Guidelines</a></li>
                         <li><a href="http://openstack.org/brand/openstack-trademark-policy/">Trademark Policy</a></li>
                         <li><a href="http://openstack.org/privacy/">Privacy Policy</a></li>
-                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributors_License_Agreement">OpenStack CLA</a></li>
+                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributor_License_Agreement">OpenStack CLA</a></li>
                     </ul>
                 </div>
                 <div class="col-lg-4 col-sm-4">

--- a/summit/templates/SummitSimplePage.ss
+++ b/summit/templates/SummitSimplePage.ss
@@ -66,7 +66,7 @@
                         <li><a href="http://openstack.org/brand/">Logos & Guidelines</a></li>
                         <li><a href="http://openstack.org/brand/openstack-trademark-policy/">Trademark Policy</a></li>
                         <li><a href="http://openstack.org/privacy/">Privacy Policy</a></li>
-                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributors_License_Agreement">OpenStack CLA</a></li>
+                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributor_License_Agreement">OpenStack CLA</a></li>
                     </ul>
                 </div>
                 <div class="col-lg-4 col-sm-4">

--- a/themes/openstack/templates/Layout/Includes/Footer.ss
+++ b/themes/openstack/templates/Layout/Includes/Footer.ss
@@ -36,7 +36,7 @@
                         <li><a href="http://openstack.org/brand/">Logos & Guidelines</a></li>
                         <li><a href="http://openstack.org/brand/openstack-trademark-policy/">Trademark Policy</a></li>
                         <li><a href="http://openstack.org/privacy/">Privacy Policy</a></li>
-                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributors_License_Agreement">OpenStack CLA</a></li>
+                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributor_License_Agreement">OpenStack CLA</a></li>
                     </ul>
                 </div>
                 <div class="col-lg-4 col-sm-4">

--- a/themes/openstack/templates/SummitStaticAboutPage.ss
+++ b/themes/openstack/templates/SummitStaticAboutPage.ss
@@ -366,7 +366,7 @@
                         <li><a href="http://openstack.org/brand/">Logos & Guidelines</a></li>
                         <li><a href="http://openstack.org/brand/openstack-trademark-policy/">Trademark Policy</a></li>
                         <li><a href="http://openstack.org/privacy/">Privacy Policy</a></li>
-                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributors_License_Agreement">OpenStack CLA</a></li>
+                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributor_License_Agreement">OpenStack CLA</a></li>
                     </ul>
                 </div>
                 <div class="col-lg-4 col-sm-4">

--- a/themes/openstack/templates/SummitStaticSponsorPage.ss
+++ b/themes/openstack/templates/SummitStaticSponsorPage.ss
@@ -575,7 +575,7 @@
                         <li><a href="http://openstack.org/brand/">Logos & Guidelines</a></li>
                         <li><a href="http://openstack.org/brand/openstack-trademark-policy/">Trademark Policy</a></li>
                         <li><a href="http://openstack.org/privacy/">Privacy Policy</a></li>
-                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributors_License_Agreement">OpenStack CLA</a></li>
+                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute#Contributor_License_Agreement">OpenStack CLA</a></li>
                     </ul>
                 </div>
                 <div class="col-lg-4 col-sm-4">


### PR DESCRIPTION
As noted by Andreas Jaegar, the url to the CLA in the footer
contained a typo.

https://bugs.launchpad.net/openstack-org/+bug/1520046