### PR TITLE
Summit banner link fixed for Austin Summit

### DIFF
--- a/events/templates/Layout/EventHolder.ss
+++ b/events/templates/Layout/EventHolder.ss
@@ -8,7 +8,7 @@
     </div>
     <div class="row">
         <div class="col-lg-12">
-            <a href="https://www.openstack.org/summit/tokyo-2015/">
+            <a href="https://www.openstack.org/summit/austin-2016/">
                 <div class="event-ad-lrg"></div>
             </a>
         </div>


### PR DESCRIPTION
Current banner in http://www.openstack.org/community/events/
is already updated for Austin Summit, but the link is still Tokyo Summit.