### PR TITLE
Changes "Contribute" link on the bottom

### DIFF
--- a/themes/openstack/templates/Layout/Includes/Footer.ss
+++ b/themes/openstack/templates/Layout/Includes/Footer.ss
@@ -18,7 +18,7 @@
                         <li><a href="http://openstack.org/community/events/">Events</a></li>
                         <li><a href="http://openstack.org/community/jobs/">Jobs</a></li>
                         <li><a href="http://openstack.org/foundation/companies/">Companies</a></li>
-                        <li><a href="https://wiki.openstack.org/wiki/How_To_Contribute">Contribute</a></li>
+                        <li><a href="http://docs.openstack.org/infra/manual/developers.html">Contribute</a></li>
                     </ul>
                 </div>
                 <div class="col-lg-2 col-sm-2">


### PR DESCRIPTION
I have found inconsistency between www.openstack.org and groups.openstack.org,
After seeing https://review.openstack.org/#/c/139421/ , I think new link in www.o.o is better than previous one.

Moreover, it can address one bug: https://bugs.launchpad.net/openstack-org/+bug/1528978 .
