### PR TITLE
Update current guidelines on interop page

### DIFF
--- a/themes/openstack/templates/Layout/InteropPage.ss
+++ b/themes/openstack/templates/Layout/InteropPage.ss
@@ -112,8 +112,8 @@
     </p>
     <p>
         The two most recent versions approved by the board are
-        "<a title="2015.05 DefCore Capabilities" href="http://git.openstack.org/cgit/openstack/defcore/tree/2015.05.json" target="_blank">2015.05</a>"
-        and "<a title="Defcore 2015.07 Guideline" href="http://git.openstack.org/cgit/openstack/defcore/tree/2015.07.json">2015.07</a>".
+        "<a title="2015.07 DefCore Capabilities" href="http://git.openstack.org/cgit/openstack/defcore/tree/2015.07.json" target="_blank">2015.07</a>"
+        and "<a title="Defcore 2016.01 Guideline" href="http://git.openstack.org/cgit/openstack/defcore/tree/2016.01.json">2016.01</a>".
         The list of required capabilities (with must-pass tests) and designated code sections are published on
         <a title="OpenStack DefCore Repository" href="http://git.openstack.org/cgit/openstack/defcore/tree/" target="_blank">git.openstack.org</a>&nbsp;
         and summarized below. Once a company verifies their products include the appropriate designated sections and submit API test results, they will


### PR DESCRIPTION
Updates the current active guidelines on the OpenStack DefCore/Interoperability page.