### PR TITLE
Migration script to deprecate VideoPresentation table

### DIFF
--- a/migrations/migrations.yml
+++ b/migrations/migrations.yml
@@ -18,3 +18,4 @@ migrations:
   - CreateSummitFrontEndAdminGroupMigration
   - PresentationSpeakerSummitConfirmationMigration
   - ClearOlderIngestTaskMigration
+  - VideoPresentationMigration

--- a/summit/code/infrastructure/active_records/events/presentations/Presentation.php
+++ b/summit/code/infrastructure/active_records/events/presentations/Presentation.php
@@ -46,6 +46,7 @@ class Presentation extends SummitEvent implements IPresentation
         'ProblemAddressed'        => 'HTMLText',
         'AttendeesExpectedLearnt' => 'HTMLText',
         'SelectionMotive'         => 'HTMLText',
+        'Legacy'				  => 'Boolean'
     );
 
     private static $defaults = array

--- a/summit/code/infrastructure/active_records/events/presentations/Presentation.php
+++ b/summit/code/infrastructure/active_records/events/presentations/Presentation.php
@@ -46,7 +46,7 @@ class Presentation extends SummitEvent implements IPresentation
         'ProblemAddressed'        => 'HTMLText',
         'AttendeesExpectedLearnt' => 'HTMLText',
         'SelectionMotive'         => 'HTMLText',
-        'Legacy'				  => 'Boolean'
+        'Legacy'		  => 'Boolean'
     );
 
     private static $defaults = array

--- a/summit/code/migrations/VideoPresentationMigration.php
+++ b/summit/code/migrations/VideoPresentationMigration.php
@@ -1,0 +1,294 @@
+<?php
+
+class VideoPresentationMigration extends AbstractDBMigrationTask {
+
+    protected $title = "VideoPresentation to PresentationVideo Migration";
+
+    protected $description = "Deprecates the old VideoPresentation table in favor of PresentationMaterial (PresentationVideo). Backfills legacy Summit records and the Presentation records that should relate to them.";
+
+	/**
+	 * Helper method to write context sensitive line breaks
+	 * @param  integer $times Number of repetitinos
+	 * @return string
+	 */
+	private function br ($times = 1) {
+		return str_repeat(Director::is_cli() ? PHP_EOL : '<br>', $times);
+	}
+
+
+	/**
+	 * Guarantees that the old summits that pre-date the Summit object are represented
+	 * @return void
+	 */
+	private function ensureLegacySummits () {
+		if(!Summit::get()->filter('Title:PartialMatch', 'San Diego')->first()) {
+			$sanDiego = Summit::create([
+				'Title' => 'San Diego',
+		        'SummitBeginDate' => '2012-10-15 00:00:00',
+		        'SummitEndDate' => '2012-10-18 00:00:00',
+		        'SubmissionBeginDate' => '2012-08-15 00:00:00',
+		        'SubmissionEndDate' => '2012-08-18 00:00:00',
+		        'VotingBeginDate' => '2012-08-20 00:00:00',
+		        'VotingEndDate' => '2012-08-25 00:00:00',
+		        'SelectionBeginDate' => '2012-09-15 00:00:00',
+		        'SelectionEndDate' => '2012-09-18 00:00:00',
+		        'RegistrationBeginDate' => '2012-10-01 00:00:00',
+		        'RegistrationEndDate' => '2012-10-10 00:00:00',
+		        'StartShowingVenuesDate' => '2012-05-05 00:00:00',
+		        'TimeZone' => '132'
+			]);
+			$sanDiego->write();
+			echo "Created San Diego summit!".$this->br();
+		}
+		if(!Summit::get()->filter('Title:PartialMatch', 'Portland')->first()) {
+			$portland = Summit::create([
+				'Title' => 'Portland',
+		        'SummitBeginDate' => '2013-04-15 00:00:00',
+		        'SummitEndDate' => '2013-04-18 00:00:00',
+		        'SubmissionBeginDate' => '2013-01-15 00:00:00',
+		        'SubmissionEndDate' => '2013-01-18 00:00:00',
+		        'VotingBeginDate' => '2013-02-20 00:00:00',
+		        'VotingEndDate' => '2013-02-25 00:00:00',
+		        'SelectionBeginDate' => '2013-03-15 00:00:00',
+		        'SelectionEndDate' => '2013-03-18 00:00:00',
+		        'RegistrationBeginDate' => '2013-04-01 00:00:00',
+		        'RegistrationEndDate' => '2013-04-10 00:00:00',
+		        'StartShowingVenuesDate' => '2013-01-01 00:00:00',
+		        'TimeZone' => '132'
+			]);
+			$portland->write();
+			echo "Created Portland summit!".$this->br();
+		}
+		if(!Summit::get()->filter('Title:PartialMatch', 'Atlanta')->first()) {
+			$atlanta = Summit::create([
+				'Title' => 'Atlanta',
+		        'SummitBeginDate' => '2013-05-05 00:00:00',
+		        'SummitEndDate' => '2013-05-08 00:00:00',
+		        'SubmissionBeginDate' => '2013-01-15 00:00:00',
+		        'SubmissionEndDate' => '2013-01-18 00:00:00',
+		        'VotingBeginDate' => '2013-02-20 00:00:00',
+		        'VotingEndDate' => '2013-02-25 00:00:00',
+		        'SelectionBeginDate' => '2013-03-15 00:00:00',
+		        'SelectionEndDate' => '2013-03-18 00:00:00',
+		        'RegistrationBeginDate' => '2013-04-01 00:00:00',
+		        'RegistrationEndDate' => '2013-04-10 00:00:00',
+		        'StartShowingVenuesDate' => '2013-01-01 00:00:00',
+		        'TimeZone' => '151'
+			]);
+			$atlanta->write();
+			echo "Created Atlanta summit!".$this->br();
+		}
+
+	}
+
+
+	/**
+	 * Guarantees that all VideoPresentation objects in the database have a summit ID.
+	 * NB: this relies on string matching voodoo.
+	 * @param  array  $map Map of summit names to ID
+	 * @return void
+	 */
+	private function ensureVideoPresentationSummitIDs($map = array ()) {
+		foreach(VideoPresentation::get() as $v) {
+			$title = $v->PresentationCategoryPage()->Parent()->MenuTitle;
+			foreach($map as $s => $id) {
+				if(strpos($title, $s) !== false) {
+					$v->SummitID = $id;
+					$v->write();
+					break;
+				}
+			}
+			if(!Summit::get()->byID($v->SummitID)) {
+				echo "$title did not match any summits".$this->br();
+				var_dump($map);
+				die();
+			}
+		}		
+	}
+
+
+	/**
+	 * Some VideoPresentation objects have wacky d/m/y dates that are stored as Varchar.
+	 * This method fixes those to be Y-m-d H:i:s
+	 * 
+	 * There are also some records with weird alphanumeric values like "S55", so we throw those out.
+	 * 
+	 * @param  VideoPresentation $v     
+	 * @param  string            $field The date field name to update
+	 * @return VideoPresentation
+	 */
+	private function normaliseDateTime(VideoPresentation $v, $field) {
+		if(strpos($v->$field, '/') !== false) {
+			if(strpos($v->$field, ':') === false) {
+				$v->$field .= ' 00:00';
+			}
+			$v->$field = DateTime::createFromFormat('j/n/y H:i', $v->$field)->format('Y-m-d H:i:s');
+		}
+		else {
+			$v->$field = null;
+		}
+
+		return $v;
+	}
+
+
+	/**
+	 * Given a VideoPresentation object, create a Presentation
+	 * @param  int            $id A forced ID (SummitEvent and Presentation tables are offset)
+	 * @param  VideoPresentation $v 
+	 * @return Presentation
+	 */
+	private function createLegacyPresentation($id, VideoPresentation $v) {
+		return Presentation::create([
+			'ID' => $id,
+			'Title' => $v->Name,
+			'Description' => $v->Description,
+			'StartDate' => $v->StartTime,
+			'EndDate' => $v->EndTime,
+			'Published' => true,
+			'PublishedDate' => $v->Created,
+			'SummitID' => $v->SummitID,
+			'Legacy' => true
+		]);
+	}
+
+
+	/**
+	 * Attempt to add speakers to the presentation by fuzzy matching the FirstName / Surname
+	 * @param Presentation      $p 
+	 * @param VideoPresentation $v 
+	 */
+	private function addLegacySpeakers(Presentation $p, VideoPresentation $v) {
+		$speakers = explode(',', $v->Speakers);
+		foreach($speakers as $speakerName) {
+			$speaker = PresentationSpeaker::get()->where("CONCAT(FirstName, ' ', LastName) = '".Convert::raw2sql($speakerName)."'");
+			if(!$speaker->exists()) {
+				//echo "**** No speakers found! {$v->Speakers}".$this->br();
+				$member = Member::get()->where("CONCAT(FirstName, ' ', Surname) = '".Convert::raw2sql($speakerName)."'");
+				if($member->exists()) {
+					//echo "******* found {$member->count()} members that match the name".$this->br();
+				}
+			}
+			else if($speaker->count() > 1) {
+				// echo "**** Multiple speakers found".$this->br();
+				// var_dump($speaker->map('Name', 'MemberID')->toArray());
+			}
+			else {
+				$p->Speakers()->add($speaker->first());
+				echo "Added speaker " . $speaker->first()->getName();
+			}
+		}
+
+		return $p;
+	}
+
+
+	/**
+	 * Create a PresentationVideo object for a presentation from a VideoPresentation
+	 * @param  Presentation      $p 
+	 * @param  VideoPresentation $v 
+	 * @return PresentationVideo
+	 */
+	private function createLegacyVideoMaterial(Presentation $p, VideoPresentation $v) {
+		return PresentationVideo::create([
+			'PresentationID' => $p->ID,
+			'Name' => $v->Name,
+			'DisplayOnSite' => $v->DisplayOnSite,
+			'YouTubeID' => $v->YouTubeID,
+			'Featured' => $v->Featured
+		]);		
+	}
+
+
+	/**
+	 * Performs the migration
+	 */
+	public function doUp () {
+		// We're mocking some stuff, e.g. Summit, Presentation, and we need some forgiveness here
+		Config::inst()->update('DataObject', 'validation_enabled', false);
+		
+		// Add the old SD / Portland summits
+		$this->ensureLegacySummits();
+		echo $this->br(2);
+		$summitToIDMap = Summit::get()->map('Title', 'ID')->toArray();
+		echo "Ensuring VideoPresentation objects have SummitIDs...";
+		$this->ensureVideoPresentationSummitIDs($summitToIDMap);
+		echo "Done.".$this->br(2);
+
+		// Presentations weren't always SummitEvents, so the tables are out of sync.
+		// Get the higer of the two ID increments to run a counter and force the ID.
+		$maxSummitEventID = DB::query("SELECT MAX(ID) FROM SummitEvent")->value();
+		$maxPresentationID = DB::query("SELECT MAX(ID) FROM Presentation")->value();
+		$idCounter = max($maxSummitEventID, $maxPresentationID);
+		$idCounter++;
+		
+		$total = VideoPresentation::get()->count();
+		$i = 0;
+		echo "Migrating VideoPresentations...".$this->br(3);		
+		foreach(VideoPresentation::get() as $v) {
+			$i++;			
+			echo "{$i} / {$total} ....";
+
+			if(!$v->YouTubeID) {
+				echo "No YouTubeID. Skipping.".$this->br();
+				continue;
+			}
+			
+			// Match an existing Presentation object by name and summit
+			$originalPresentation = Presentation::get()->filter([
+				'Title' => $v->Name,
+				'SummitID' => $v->SummitID
+			])->first();
+
+			if(!$originalPresentation) {
+				$v = $this->normaliseDateTime($v, 'StartTime');
+				$v = $this->normaliseDateTime($v, 'EndTime');
+
+				$originalPresentation = $this->createLegacyPresentation($idCounter, $v);
+				$originalPresentation->write(false, true);
+				$idCounter++;
+				
+				echo "Created presentation {$v->ID} -> {$originalPresentation->ID}...";
+				$originalPresentation = $this->addLegacySpeakers($originalPresentation, $v);
+			}
+
+			$material = $this->createLegacyVideoMaterial($originalPresentation, $v);
+			$material->write();
+			$v->write();
+			echo "Created video." . $this->br();
+		}
+	}
+
+
+	/**
+	 * Reverses the migration	 
+	 */
+	public function doDown () {
+		PresentationVideo::get()->removeAll();
+		if(!PresentationVideo::get()->exists()) {
+			echo "Deleted all presentation video materials".$this->br();			
+		}
+		else {
+			echo "*** FAIL: Did not delete presentation video materials".$this->br();			
+		}
+		foreach(Presentation::get()->filter('Legacy', true) as $p) {
+			$p->Speakers()->setByIdList(array ());
+			$p->delete();
+		}
+		if(!Presentation::get()->filter('Legacy', true)->exists()) {
+			echo "Deleted all legacy presentations".$this->br();
+		}
+		else {
+			echo "*** FAIL: Did not delete all legacy presentations".$this->br();
+		}
+
+		Summit::get()->filter('Title', ['San Diego','Portland', 'Atlanta'])->removeAll();
+
+		if(!Summit::get()->filter('Title', ['San Diego','Portland','Atlanta'])->exists()) {
+			echo "Deleted legacy summits".$this->br();
+		}
+		else {
+			echo "*** FAIL: Did not delete legacy summits".$this->br();
+		}
+	}
+}


### PR DESCRIPTION
## Purpose

This migration script is designed to deprecate the old `VideoPresentation` table in favour of the new `PresentationMaterial` object and its descendant `PresentationVideo`.

## Rationale

With the build of the new Summit video page, it became clear that there are some serious integrity issues with the relation between Summit, Presentation, and Videos, particularly in older Summits. In order to create a user experience that will deliver videos across all summits, it is necessary to eliminate idiosyncrasies and establish a consistent data model that we can use long term.

## What this does

First, the script ensures that old summits that predate the `Summit` object (San Diego, Portland, Atlanta) are stored in the database as hollow shells, with the bare minimum fields populated, with minimal real-life accuracy.  The purpose of these records is to act merely as holders for the `Presentation` and `PresentationVideo` objects.

Next, `VideoPresentation` objects are each assigned a `SummitID`, as most of them are lacking one. This has to be determined using a heuristic. Using the associated `PresentationCategoryPage`, it matches the summit name as a substring in the page title, e.g. "Paris Summit 2014" will match the summit titled "Paris," and a `SummitID` of `3` will be assigned.

Lastly, the script loops through all `VideoPresentation` records in the database and attempts to find their associated `Presentation` object, which is the source of content for `VideoPresentation`. The `PresentationID` is *not* stored on this record, which means it's neccessary to use another heuristic to find or create that `Presentation` record. It is assumed that every `VideoPresentation` object shares a name with the `Presentation` object that feeds it, so the script tries to match the `Name` and `SummitID` fields to an existing `Presentation`. Most of those don't get hits (not until Tokyo). To fill in the gaps, the script retroactively creates a `Presentation` object for the `VideoPresentation` with the correct `SummitID`. From there, it is trivial to create the final `PresentationVideo` object and assign it to the `Presentation`.

## Reversal

A full reversal script is included.