### PR TITLE
Fix the share URL on event detail view

### DIFF
--- a/summit/templates/Layout/SummitAppEventPage.ss
+++ b/summit/templates/Layout/SummitAppEventPage.ss
@@ -90,7 +90,7 @@
                 <script type="application/javascript">
                     var share_info =
                     {
-                        url: "{$AbsoluteLink}event/{$Event.ID}",
+                        url: "{$AbsoluteLink}events/{$Event.ID}",
                         title : "{$Event.Title.JS}",
                         description: "{$Event.ShortDescription().JS}",
                         image: "/themes/openstack/images/openstack-logo-full.png",


### PR DESCRIPTION
The URL component should be 'events' not 'event'.