### PR TITLE
Add EventHolder for App Hackathons

### DIFF
--- a/events/code/ui/EventHolder.php
+++ b/events/code/ui/EventHolder.php
@@ -127,7 +127,7 @@ class EventHolder_Controller extends Page_Controller {
 
     function FutureOpenstackHackathonsEvents($num) {
         $filter_array = array('EventEndDate:GreaterThanOrEqual'=> date('Y-m-d'));
-        $filter_array['EventCategory'] = 'Openstack App Hackathon';
+        $filter_array['EventCategory'] = 'Hackathons';
         $pulled_events = EventPage::get()->filter($filter_array)->sort(array('EventStartDate'=>'ASC','EventContinent'=>'ASC'))->limit($num);
 
         return $pulled_events;

--- a/events/code/ui/EventHolder.php
+++ b/events/code/ui/EventHolder.php
@@ -21,6 +21,11 @@ class EventHolder extends Page {
        'OpenstackDaysVideoDesc1' => 'Text',
        'OpenstackDaysVideoID2'   => 'Text',
        'OpenstackDaysVideoDesc2' => 'Text',
+       'OpenstackHackathonsContent'    => 'HTMLText',
+       'OpenstackHackathonsVideoID1'   => 'Text',
+       'OpenstackHackathonsVideoDesc1' => 'Text',
+       'OpenstackHackathonsVideoID2'   => 'Text',
+       'OpenstackHackathonsVideoDesc2' => 'Text',
    );
 
    private static $has_one = array(
@@ -34,6 +39,11 @@ class EventHolder extends Page {
         $fields->addFieldToTab("Root.OpenstackDays", new TextField("OpenstackDaysVideoDesc1", "Video Description"));
         $fields->addFieldToTab("Root.OpenstackDays", new TextField("OpenstackDaysVideoID2", "Youtube ID 2"));
         $fields->addFieldToTab("Root.OpenstackDays", new TextField("OpenstackDaysVideoDesc2", "Video Description"));
+        $fields->addFieldToTab("Root.OpenstackHackathons", new HtmlEditorField("OpenstackHackathonsContent", "Intro Text"));
+        $fields->addFieldToTab("Root.OpenstackHackathons", new TextField("OpenstackHackathonsVideoID1", "Youtube ID 1"));
+        $fields->addFieldToTab("Root.OpenstackHackathons", new TextField("OpenstackHackathonsVideoDesc1", "Video Description"));
+        $fields->addFieldToTab("Root.OpenstackHackathons", new TextField("OpenstackHackathonsVideoID2", "Youtube ID 2"));
+        $fields->addFieldToTab("Root.OpenstackHackathons", new TextField("OpenstackHackathonsVideoDesc2", "Video Description"));
 		return $fields;
 	}
       
@@ -49,7 +59,8 @@ class EventHolder_Controller extends Page_Controller {
 		'AjaxFutureEvents',
 		'AjaxFutureSummits',
 		'AjaxPastSummits',
-        'openstackdays'
+        'openstackdays',
+        'openstackhackathons'
 	);
 
 	function init() {
@@ -109,6 +120,14 @@ class EventHolder_Controller extends Page_Controller {
     function FutureOpenstackDaysEvents($num) {
         $filter_array = array('EventEndDate:GreaterThanOrEqual'=> date('Y-m-d'));
         $filter_array['EventCategory'] = 'Openstack Days';
+        $pulled_events = EventPage::get()->filter($filter_array)->sort(array('EventStartDate'=>'ASC','EventContinent'=>'ASC'))->limit($num);
+
+        return $pulled_events;
+    }
+
+    function FutureOpenstackHackathonsEvents($num) {
+        $filter_array = array('EventEndDate:GreaterThanOrEqual'=> date('Y-m-d'));
+        $filter_array['EventCategory'] = 'Openstack App Hackathon';
         $pulled_events = EventPage::get()->filter($filter_array)->sort(array('EventStartDate'=>'ASC','EventContinent'=>'ASC'))->limit($num);
 
         return $pulled_events;
@@ -208,5 +227,10 @@ class EventHolder_Controller extends Page_Controller {
     function openstackdays() {
         Requirements::css('events/css/openstackdays.css');
         return $this->renderWith(array('EventHolder_openstackdays','EventHolder','Page'));
+    }
+
+    function openstackhackathons() {
+        Requirements::css('events/css/openstackhackathons.css');
+        return $this->renderWith(array('EventHolder_openstackhackathons','EventHolder','Page'));
     }
 }

--- a/events/code/ui/admin/SangriaPageEventExtension.php
+++ b/events/code/ui/admin/SangriaPageEventExtension.php
@@ -26,8 +26,8 @@ final class SangriaPageEventExtension extends Extension {
 	}
 
 	public function onBeforeInit(){
-		Config::inst()->update(get_class($this), 'allowed_actions', array('ViewEventDetails','ViewPostedEvents','ViewOpenstackDaysEvents','FeaturedEventForm','saveFeaturedEvent'));
-		Config::inst()->update(get_class($this->owner), 'allowed_actions', array('ViewEventDetails','ViewPostedEvents','ViewOpenstackDaysEvents','FeaturedEventForm','saveFeaturedEvent'));
+		Config::inst()->update(get_class($this), 'allowed_actions', array('ViewEventDetails','ViewPostedEvents','ViewOpenstackDaysEvents','ViewOpenstackHackathonsEvents','FeaturedEventForm','saveFeaturedEvent'));
+		Config::inst()->update(get_class($this->owner), 'allowed_actions', array('ViewEventDetails','ViewPostedEvents','ViewOpenstackDaysEvents','ViewOpenstackHackathonsEvents','FeaturedEventForm','saveFeaturedEvent'));
 	}
 
 	public function EventRegistrationRequestForm() {
@@ -143,6 +143,12 @@ final class SangriaPageEventExtension extends Extension {
         $this->commonScripts();
         Requirements::javascript('events/js/admin/sangria.page.event.extension.js');
         return $this->owner->getViewer('ViewOpenstackDaysEvents')->process($this->owner);
+    }
+
+    public function ViewOpenstackHackathonsEvents(){
+        $this->commonScripts();
+        Requirements::javascript('events/js/admin/sangria.page.event.extension.js');
+        return $this->owner->getViewer('ViewOpenstackHackathonsEvents')->process($this->owner);
     }
 
 	public function getQuickActionsExtensions(&$html){

--- a/events/css/openstackhackathons.css
+++ b/events/css/openstackhackathons.css
@@ -1,0 +1,216 @@
+.oshacks-hero {
+    background: url('/themes/openstack/images/oshacks/oshacks-bkgd.png') no-repeat center center;
+    background-size: cover;
+}
+
+.oshacks-hero h1 {
+    color: white;
+}
+
+.oshacks-intro {
+    text-align: center;
+    margin: 20px 0 50px; }
+.oshacks-intro h2 {
+    text-align: center;
+    font-size: 1.7em; }
+.oshacks-intro p {
+    color: #2A4E68;
+    margin-bottom: 20px; }
+.oshacks-intro a {
+    text-decoration: underline; }
+.oshacks-intro .video {
+    margin: 20px 0; }
+.oshacks-intro .video iframe {
+    max-width: 100%; }
+
+@media (max-width: 767px) {
+    .oshacks-intro .video iframe {
+        height: 190px; } }
+
+.inner-oshacks {
+    background: white;
+    padding: 30px; }
+.inner-oshacks h3 {
+    margin-bottom: 30px; }
+.inner-oshacks p {
+    margin-bottom: 10px; }
+.inner-oshacks p a {
+    text-decoration: underline; }
+.inner-oshacks hr {
+    margin: 30px 0; }
+.oshacks-events .row{
+    border-bottom: 1px solid #D4DCE5;
+    text-align: left;
+    padding-bottom: 20px;
+    margin-bottom: 20px;
+    display: block;
+}
+
+.inner-oshacks .oshacks-event .osd-date {
+    background: #fff;
+    border: 2px solid #DA422F;
+    border-radius: 4px;
+    padding: 5px 10px;
+    color: #DA422F;
+    width: auto;
+    font-size: 10px;
+    text-align: center;
+    max-width: 150px; }
+.inner-oshacks .oshacks-event .osd-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: #333;
+    width: auto;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 5px; }
+.inner-oshacks .oshacks-event .osd-location {
+    font-style: italic;
+    color: #333;
+    font-weight: 300;
+    margin-top: 5px; }
+.inner-oshacks .oshacks-event .osd-link {
+    text-align: right;
+    margin-top: 5px;
+    padding-right: 45px;
+    position: relative; }
+.inner-oshacks .oshacks-event .osd-link:before {
+    content: 'More Details'; }
+.inner-oshacks .oshacks-event .osd-link:after {
+    position: absolute;
+    font-family: FontAwesome;
+    top: -5px;
+    right: 0;
+    content: "\f105";
+    font-size: 1.5em;
+    color: #30739C;
+    width: 30px;
+    height: 30px;
+    text-align: center;
+    border-radius: 100%;
+    background: #edf2f7; }
+
+@media (max-width: 767px) {
+    .inner-oshacks a.oshacks-event .osd-link:before {
+        content: ' '; } }
+
+p.question {
+    font-weight: 700;
+    margin-bottom: 5px; }
+
+p.answer {
+    margin-bottom: 20px; }
+
+.software-tab-wrapper {
+    width: 100%;
+    border-bottom: 1px solid #D4DCE5; }
+.software-tab-wrapper ul.project-tabs {
+    margin: 0;
+    border-bottom: 0; }
+.software-tab-wrapper ul.project-tabs li {
+    float: left;
+    margin-bottom: -1px;
+    position: relative;
+    /*			&:nth-last-of-type(-n+2)  a {
+              color: #bbb;
+              &:hover {
+                  color: $darkblue;
+              }
+          }*/ }
+.software-tab-wrapper ul.project-tabs li a {
+    margin-right: 2px;
+    line-height: 1.42857;
+    border: 1px solid transparent;
+    border-radius: 0;
+    position: relative;
+    display: block;
+    padding: 15px 30px;
+    font-size: 12px;
+    color: #698296;
+    text-transform: uppercase;
+    font-weight: 400; }
+.software-tab-wrapper ul.project-tabs li a:hover {
+    text-decoration: none;
+    color: #2A4E68;
+    background: white; }
+.software-tab-wrapper ul.project-tabs li.active a {
+    background: #edf2f7;
+    border-right: 1px solid #D4DCE5;
+    border-top: 2px solid #248EC7;
+    border-left: 1px solid #D4DCE5;
+    color: #2A4E68; }
+.software-tab-wrapper ul.project-tabs li.active a:hover {
+    text-decoration: none; }
+
+@media (max-width: 1200px) {
+    .software-tab-wrapper ul.project-tabs li a {
+        padding: 15px 20px; } }
+
+@media (max-width: 991px) {
+    .software-tab-wrapper .container {
+        width: 100%; }
+    .software-tab-wrapper ul.project-tabs li a {
+        padding: 15px 15px;
+        font-size: 12px; } }
+
+@media (max-width: 840px) {
+    .software-tab-wrapper .container {
+        width: 100%; }
+    .software-tab-wrapper ul.project-tabs li a {
+        padding: 5px 11px;
+        font-size: 12px; } }
+
+@media (max-width: 790px) {
+    .software-tab-wrapper ul.project-tabs li {
+        width: 100%;
+        margin: 2px; }
+    .software-tab-wrapper ul.project-tabs li a {
+        width: 100%;
+        font-size: 12px; }
+    .software-tab-wrapper ul.project-tabs li.active a {
+        border-right: 1px solid transparent;
+        border-top: 2px solid #248EC7;
+        border-left: 1px solid transparent;
+        border-radius: 4px; } }
+
+.software-main-wrapper {
+    background: #edf2f7;
+    padding: 75px 0 65px; 
+    margin-bottom: -50px;
+}
+.software-main-wrapper .inner-software {
+    background: white;
+    border-radius: 4px;
+    padding: 40px; }
+
+@media (max-width: 550px) {
+    .software-main-wrapper .inner-software {
+        padding: 40px 15px; } }
+
+.software-main-wrapper .inner-software .featured-config {
+    background-color: #2A4E68;
+    background-size: cover;
+    margin: 30px 0;
+    padding: 25px; }
+.software-main-wrapper .inner-software .featured-config h3 {
+    color: white;
+    margin: 0 0 25px; }
+.software-main-wrapper .inner-software .featured-config p {
+    font-size: 0.9em;
+    color: #FFFFFF;
+    line-height: 1.3em;
+    margin-bottom: 60px; }
+.software-main-wrapper .inner-software .featured-config a.featured-config-btn {
+    display: block;
+    color: white;
+    text-transform: uppercase;
+    text-align: center;
+    font-size: 0.9em;
+    font-weight: 600;
+    background: #248EC7;
+    border-radius: 4px;
+    padding: 10px; }
+.software-main-wrapper .inner-software .featured-config a.featured-config-btn:hover {
+    text-decoration: none;
+    background: #29abe2; }

--- a/events/templates/Layout/EventHolder_openstackhackathons.ss
+++ b/events/templates/Layout/EventHolder_openstackhackathons.ss
@@ -1,0 +1,147 @@
+</div>
+<div class="oshacks-hero">
+    <div class="container">
+        <div class="row">
+            <div class="col-sm-12">
+                <h1>OpenStack App Hackathons</h1>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="container">
+    <div class="row">
+        <div class="col-sm-10 col-sm-push-1 oshacks-intro">
+            $OpenstackHackathonsContent
+            <% if $OpenstackHackathonsVideoID1 && $OpenstackHackathonsVideoID2 %>
+            <div class="row">
+                <div class="col-xs-6">
+                    <div class="video">
+                        <iframe src="https://www.youtube.com/embed/{$OpenstackHackathonsVideoID1}?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen=""></iframe>
+                        <p>
+                            $OpenstackHackathonsVideoDesc1
+                        </p>
+                    </div>
+                </div>
+                <div class="col-xs-6">
+                    <div class="video">
+                        <iframe src="https://www.youtube.com/embed/{$OpenstackHackathonsVideoID2}?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen=""></iframe>
+                        <p>
+                            $OpenstackHackathonsVideoDesc2
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <% end_if %>
+        </div>
+    </div>
+</div>
+
+<div id="oshacks-tab-stop"></div>
+
+<div class="software-tab-wrapper">
+    <div class="container">
+        <ul class="nav nav-tabs project-tabs" id="oshacks-tabs" role="tablist">
+            <li class="active"><a href="#events_tab" role="tab" data-toggle="tab">Upcoming Events</a></li>
+            <li><a href="#host_tab" role="tab" data-toggle="tab">Host An OpenStack App Hackathon</a></li>
+        </ul>
+    </div>
+</div>
+
+<div class="software-main-wrapper">
+    <div class="container inner-oshacks">
+        <!-- Begin Page Content -->
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane fade in active" id="events_tab">
+                <div class="row">
+                    <div class="col-sm-12">
+                        <h3>Upcoming OpenStack App Hackathons</h3>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-12 oshacks-events">
+                        <% if $FutureOpenstackHackathonsEvents(22) %>
+                            <% loop $FutureOpenstackHackathonsEvents(22) %>
+
+                                    <div class="row oshacks-event">
+                                        <div class="col-sm-2 col-xs-3">
+                                            <div class="osd-date"> $formatDateRange </div>
+                                        </div>
+                                        <div class="col-sm-4 col-xs-4">
+                                            <div class="osd-name"> $Title </div>
+                                        </div>
+                                        <div class="col-sm-3 col-xs-3">
+                                            <div class="osd-location"> $Location, $Continent </div>
+                                        </div>
+                                        <% if $EventLink %>
+                                        <div class="col-sm-3 col-xs-2">
+                                            <a rel="nofollow" href="$EventLink" target="_blank" data-type="$EventCategory">
+                                                <div class="osd-link"></div>
+                                            </a>
+                                        </div>
+                                        <% end_if %>
+                                    </div>
+                            <% end_loop %>
+                        <% else %>
+                            <h3>Sorry, there are no upcoming events listed at the moment.</h3>
+                            <p class="details">
+                                Wow! It really rare that we don't have any upcoming events on display.
+                                Somewhere in the world there's sure to be an OpenStack event in the near future&mdash;
+                                We probably just need to update this list. Please check back soon for more details.
+                            </p>
+                        <% end_if %>
+                    </div>
+                </div>
+            </div>
+            <div role="tabpanel" class="tab-pane fade" id="host_tab"> <!-- Host Tab -->
+                <div class="row">
+                    <div class="col-sm-12">
+                        <h3>Host An OpenStack App Hackathon</h3>
+                        <p>
+                            Are you interested in hosting an OpenStack App Hackathon in your area?
+                        </p>
+                        <p>
+                            First, get in touch with your local user group or community ambassador to see if there are already events happening and how you can get plugged in. You can reference the <a href="//groups.openstack.org/groups" target="_blank">list of user groups</a> and <a href="//groups.openstack.org/ambassador-program" target="_blank">ambassadors</a> to find one near you. OpenStack App Hackathons can require quite a bit of work to organize, so it’s ideal for user group leaders to help organize them to collaborate across organizations and leverage existing local infrastructure, such as attendee lists and regular sponsors.
+                        </p>
+                        <p>
+                            Next, <a href="//www.openstack.org/brand/event-policy/">review the event guidelines</a>.  OpenStack App Hackathons are non-commercial events and we expect them to run in accordance with the spirit of the community. This means making reasonable efforts to open the events to anyone in the community who wants to help organize, attend, or sponsor, regardless of affiliation.
+                        </p>
+                        <p>
+                            Once you’ve reviewed the guidelines, please contact <a href="mailto:flanders@openstack.org">App Hack Working Group</a> to get started.
+                        </p>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-12">
+                        <hr>
+                        <h3>FAQs</h3>
+                        <p class="question">
+                            Can anyone host an OpenStack App Hackathon?
+                        </p>
+                        <p class="answer">
+                            OpenStack App Hackathon events are typically hosted by local user groups, but anyone can get involved. If you are interested in starting a new OpenStack App Hack in your area, it’s best to get in touch with your <a href="//groups.openstack.org">local user group or regional ambassador</a>. In order to use the OpenStack brand, you must get approval from the OpenStack Foundation and meet <a href="//www.openstack.org/brand/event-policy/">the event guidelines</a>.
+                        </p>
+                        <p class="question">
+                            Who attends OpenStack App Hackathon events?
+                        </p>
+                        <p class="answer">
+                            These events are aimed at experienced developers who want to learn more about building cloud applications, and specifically OpenStack. Current events attract a couple hundred attendees. Most annual events grow and attract new participants each year, so it’s OK to start on the smaller end and build over time.
+                        </p>
+                        <p class="question">
+                            How can the App Hack Working Group help?
+                        </p>
+                        <p class="answer">
+                            The working group is comproised of leaders who have run hackathons in the past. They will provide a kit you can follow to make a successful event and provide mentoring to assist along the way.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<%--
+<% with FeaturedEvent %>
+    $Title
+    $Picture
+<% end_with %>
+--%>

--- a/sangria/templates/Layout/SangriaPage.ss
+++ b/sangria/templates/Layout/SangriaPage.ss
@@ -152,6 +152,7 @@
         <li><a href="$Top.Link(ViewEventDetails)">New Event Submissions</a></li>
         <li><a href="$Top.Link(ViewPostedEvents)">Edit Posted Events</a></li>
         <li><a href="$Top.Link(ViewOpenstackDaysEvents)">Openstask Days Events</a></li>
+        <li><a href="$Top.Link(ViewOpenstackHackathonsEvents)">Openstask Hackathons Events</a></li>
     </ul>
 
     <h2>Jobs</h2>

--- a/summit-voting-app/templates/PresentationVotingPage.ss
+++ b/summit-voting-app/templates/PresentationVotingPage.ss
@@ -7,7 +7,7 @@
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <meta name="description" content="">
       <meta name="author" content="">
-      <title>Vote For Tokyo Summit Presentations | OpenStack Open Source Cloud Computing Software</title>
+      <title>Vote For $Parent.Title Summit Presentations | OpenStack Open Source Cloud Computing Software</title>
       <!-- Bootstrap Core CSS -->
       <% require css("themes/openstack/css/bootstrap3.css") %>
       <!-- Custom CSS -->

--- a/themes/openstack/templates/Layout/Includes/Navigation_menu.ss
+++ b/themes/openstack/templates/Layout/Includes/Navigation_menu.ss
@@ -46,6 +46,7 @@
         <li role="presentation"><a role="menuitem" tabindex="-1" href="{$BaseHref}community/events/">Overview</a></li>
         <li role="presentation"><a role="menuitem" tabindex="-1" href="{$BaseHref}summit/">The OpenStack Summit</a></li>
         <li role="presentation"><a role="menuitem" tabindex="-1" href="{$BaseHref}community/events/openstackdays">OpenStack Days</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="{$BaseHref}community/events/openstackhackathons">OpenStack App Hackathons</a></li>
     </ul>
 </li>
 <li>


### PR DESCRIPTION
App Hackathons are becoming increasingly prevalent and there is no
current home for them on OpenStack.org. This change uses the same
style as OpenStack Days, to provide a way for App Hackathons to be
listed.