### PR TITLE
Make length arg of getShortBio a hard limit

### DIFF
--- a/summit/code/infrastructure/active_records/events/presentations/PresentationSpeaker.php
+++ b/summit/code/infrastructure/active_records/events/presentations/PresentationSpeaker.php
@@ -806,9 +806,11 @@ class PresentationSpeaker extends DataObject
     {
         $bio = strip_tags($this->getField('Bio'));
 
-        if (strlen($bio) < $length) return $bio;
+        if (strlen($bio) <= $length) return $bio;
 
-        $pos = strpos($bio, ' ', $length);
+        $length -= 3; // account for '...'
+        $pos = strrpos(substr($bio, 0, $length + 1), ' ');
+        if ($pos === false) $pos = $length;
         $short_bio = substr($bio, 0, $pos) . '...';
         return $short_bio;
     }


### PR DESCRIPTION
Also account for failures to find appropriate word breaks.

Previously, getShortBio would return just `'...'` if there were no spaces after the `$length`th character. You could see this, for example, at https://www.openstack.org/summit/barcelona-2016/summit-schedule/events/15968/new-in-swift-object-encryption