### PR TITLE
Fix AUC Metric OFFICIAL_USER_GROUP_ORGANIZER

### DIFF
--- a/auc-metrics/code/services/OfficialUserGroupOrganizerService.php
+++ b/auc-metrics/code/services/OfficialUserGroupOrganizerService.php
@@ -34,7 +34,7 @@ class OfficialUserGroupOrganizerService extends BaseService implements MetricSer
             );
         }
 
-        $csvPath = "https://groups.openstack.org/reports/group-contact-report/csv?token=" . GROUP_CONTACT_REPORT_TOKEN;
+        $csvPath = "https://groups.openstack.org/reports/group-contact-report/csv?token=" . GROUP_CONTACT_REPORT_TOKEN . "&status=official";
 
         $client = $this->getHTTPClient();
         $response = $client->get($csvPath);


### PR DESCRIPTION
The URL previously used included all user group organisers.
The change limits it to just official user groups, as per AUC spec.