### PR TITLE
Allow translatros to control the order of %s

### DIFF
--- a/survey_builder/templates/Layout/Includes/EntityRegularStepForm.ss
+++ b/survey_builder/templates/Layout/Includes/EntityRegularStepForm.ss
@@ -2,7 +2,7 @@
     <fieldset>
         <div class="row">
             <div class="col-md-12">
-                <h3><span class="entity-survey-title-details">$_T("survey_ui", "Your Deployments")&nbsp;-&nbsp;$_T("survey_ui", "Part %s of %s", $CurrentStepIndex, $MaxStepIndex)</span></h3>
+                <h3><span class="entity-survey-title-details">$_T("survey_ui", "Your Deployments")&nbsp;-&nbsp;$_T("survey_ui", "Part %1$s of %2$s", $CurrentStepIndex, $MaxStepIndex)</span></h3>
             </div>
         </div>
         <hr>

--- a/survey_builder/templates/Layout/Includes/Surveys_Header.ss
+++ b/survey_builder/templates/Layout/Includes/Surveys_Header.ss
@@ -1,6 +1,6 @@
 <div class="row">
     <div class="col-sm-12 survey-top">
-        <p>$_T("survey_ui", "Step <strong>%s of %s</strong> for <strong>%s</strong>",$Survey.getCurrentStepIndexNice, $Survey.getStepsCount, $CurrentMember.FullName)</p>
+        <p>$_T("survey_ui", "Step <strong>%1$s of %2$s</strong> for <strong>%3$s</strong>",$Survey.getCurrentStepIndexNice, $Survey.getStepsCount, $CurrentMember.FullName)</p>
     </div>
 </div>
 <div class="row">


### PR DESCRIPTION
When multiple %s substitions are included in a string,
translators are forced to keep the order of %s.
Otherwise the generated message will be wrong.

It seems PHP gettext has a mechanism of numbered substition
like %1$s, %2$s. This allows translator can change the order of %s.