### PR TITLE
Add sig mailing list to contributor portal

### DIFF
--- a/themes/openstack/templates/Layout/CommunityPageBis.ss
+++ b/themes/openstack/templates/Layout/CommunityPageBis.ss
@@ -207,9 +207,10 @@
                 </div>
                 <div>
                     <a href="http://lists.openstack.org/cgi-bin/mailman/listinfo/openstack">OpenStack General</a><br>
-                    <a href="http://lists.openstack.org/cgi-bin/mailman/listinfo/openstack-dev">OpenStack-dev</a><br>
-                    <a href="http://lists.openstack.org/cgi-bin/mailman/listinfo/openstack-docs">OpenStack-docs</a><br>
-                    <a href="http://lists.openstack.org/cgi-bin/mailman/listinfo/women-of-openstack">Women-of-OpenStack</a>
+                    <a href="http://lists.openstack.org/cgi-bin/mailman/listinfo/openstack-dev">OpenStack Development</a><br>
+                    <a href="http://lists.openstack.org/cgi-bin/mailman/listinfo/openstack-docs">OpenStack Documentation</a><br>
+                    <a href="http://lists.openstack.org/cgi-bin/mailman/listinfo/openstack-sigs">OpenStack Special Interest Groups</a><br>
+                    <a href="http://lists.openstack.org/cgi-bin/mailman/listinfo/women-of-openstack">Women of OpenStack</a>
                 </div>
             </div>
             <div class="col-md-4 col-sm-6 communicate-item">


### PR DESCRIPTION
Also write out the names of the various mailing lists instead of using
acronyms.