### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update --fix-missing
 
 #install required packages
-RUN apt-get install -y apt-utils openssh-server sudo curl wget nfs-common puppet puppet-common && \
+RUN apt-get --no-install-recommends install -y apt-utils openssh-server sudo curl wget nfs-common puppet puppet-common && \
     apt-get clean #cleanup to reduce image size
 
 # Create and configure vagrant user

--- a/PythonEnv.md
+++ b/PythonEnv.md
@@ -2,7 +2,7 @@
  
  ```bash
 
- sudo apt-get install python-pip python-dev libmysqlclient-dev;
+ sudo apt-get --no-install-recommends install python-pip python-dev libmysqlclient-dev;
  pip install virtualenv;
  cd survey_builder/code/model/extract_tags;
  virtualenv env;

--- a/docker.md
+++ b/docker.md
@@ -3,7 +3,7 @@
 ```bash
 wget https://releases.hashicorp.com/vagrant/2.0.0/vagrant_2.0.0_x86_64.deb
 dpkg -i vagrant_2.0.0_x86_64.deb
-apt-get install docker.io
+apt-get --no-install-recommends install docker.io
 adduser [user] docker 
 ```
 

--- a/gettext/readme.md
+++ b/gettext/readme.md
@@ -1,18 +1,18 @@
 # Requirements
 
 ````bash
- sudo apt-get install gettext
- sudo apt-get install language-pack-en-base
- sudo apt-get install language-pack-es-base
- sudo apt-get install language-pack-de-base
- sudo apt-get install language-pack-fr-base
- sudo apt-get install language-pack-ru-base
- sudo apt-get install language-pack-gr-base
- sudo apt-get install language-pack-ko-base
- sudo apt-get install language-pack-ja-base
- sudo apt-get install language-pack-id-base
- sudo apt-get install language-pack-zh-hant-base
- sudo apt-get install language-pack-zh-hans-base
+ sudo apt-get --no-install-recommends install gettext
+ sudo apt-get --no-install-recommends install language-pack-en-base
+ sudo apt-get --no-install-recommends install language-pack-es-base
+ sudo apt-get --no-install-recommends install language-pack-de-base
+ sudo apt-get --no-install-recommends install language-pack-fr-base
+ sudo apt-get --no-install-recommends install language-pack-ru-base
+ sudo apt-get --no-install-recommends install language-pack-gr-base
+ sudo apt-get --no-install-recommends install language-pack-ko-base
+ sudo apt-get --no-install-recommends install language-pack-ja-base
+ sudo apt-get --no-install-recommends install language-pack-id-base
+ sudo apt-get --no-install-recommends install language-pack-zh-hant-base
+ sudo apt-get --no-install-recommends install language-pack-zh-hans-base
 ````
 
 to compile from .po to .mo files 

--- a/init_site.sh
+++ b/init_site.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 sudo apt-get update;
-sudo apt-get install -y nodejs;
+sudo apt-get --no-install-recommends install -y nodejs;
 sudo rm -R vendor;
 sudo rm -R node_modules;
 php -r "readfile('https://getcomposer.org/installer');" > composer-setup.php

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -20,7 +20,7 @@ echo "GITHUB_OAUTH_TOKEN is $GITHUB_OAUTH_TOKEN";
 
 sudo apt-get update;
 sudo apt-get --yes upgrade;
-sudo apt-get --yes install puppet composer;
+sudo apt-get --no-install-recommends --yes install puppet composer;
 if [[ -n "$GITHUB_OAUTH_TOKEN" ]]; then
     echo "running composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN";
   	sudo -H -u vagrant bash -c "composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN";


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik raj <rajpratik71@gmail.com>