### PR TITLE
fix: Column 'Level' in where clause is ambiguous

### DIFF
--- a/summit/code/infrastructure/active_records/Summit.php
+++ b/summit/code/infrastructure/active_records/Summit.php
@@ -846,7 +846,7 @@ class Summit extends DataObject implements ISummit
         $query = new QueryObject();
         $query->addAndCondition(QueryCriteria::equal('Published', 1));
         if (!is_null($level)) {
-            $query->addAndCondition(QueryCriteria::equal('Level', $level));
+            $query->addAndCondition(QueryCriteria::equal('SummitEvent.Level', $level));
         }
 
         $query


### PR DESCRIPTION
ref https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskDueDate&view=vertical&task=3809130&stafilter=NotComplete&fileview=grid