### PR TITLE
[Task 3848895] Member Data Lookup Issue

### DIFF
--- a/members_list/code/ui/frontend/MemberListPage.php
+++ b/members_list/code/ui/frontend/MemberListPage.php
@@ -78,10 +78,9 @@ class MemberListPage_Controller extends Page_Controller
             $likeString = "Surname LIKE 'a%'";
         }
 
-
+        $IndividualMembership = Convert::raw2sql(IOpenStackMember::MembershipTypeIndividual, true);
         $list = Member::get()
-            ->where("Group_Members.GroupID = 5 AND " . $likeString)
-            ->leftJoin('Group_Members', 'Member.ID = Group_Members.MemberID')
+            ->where("MembershipType = " . $IndividualMembership . " AND " . $likeString)
             ->sort('Surname');
 
         return GroupedList::create($list);
@@ -92,8 +91,11 @@ class MemberListPage_Controller extends Page_Controller
         $member  = Member::get()->byID(intval($member_id));
         if(!is_null($member))
         {
+
             // Check to make sure they are in the foundation membership group
-            If ($member->inGroup(5, true) && $member->isActive())
+            If (
+                $member->MembershipType === IOpenStackMember::MembershipTypeIndividual &&
+                $member->isActive())
             {
                 return $member;
             }

--- a/members_list/code/ui/frontend/MemberListPage.php
+++ b/members_list/code/ui/frontend/MemberListPage.php
@@ -93,7 +93,7 @@ class MemberListPage_Controller extends Page_Controller
         {
 
             // Check to make sure they are in the foundation membership group
-            If (
+            if (
                 $member->MembershipType === IOpenStackMember::MembershipTypeIndividual &&
                 $member->isActive())
             {


### PR DESCRIPTION
## Summary

#### Original request:
This query returns a record with "id":162837 https://openstackid-resources.openstack.org/api/public/v1/members?expand=groups%2Call_affiliations%2Call_affiliations.organization&filter%5B%5D=email%3D%3Dlazekteam%40gmail.com&filter%5B%5D=membership_type%3D%3DIndividual&relations=affiliations%2Cgroups

but https://www.openstack.org/community/members/profile/162837 returns a 404 page

#### Technical request
Change member filtering from GroupID 5 to MembershipType "Individual".

## Changes
-  In `MemberList` method of `members_list/code/ui/frontend/MemberListPage.php` from `GroupID = 5` to `MembershipType = IOpenStackMember::MembershipTypeIndividual`
- In `findMember` from `inGroup(5, true)` to `MembershipType === IOpenStackMember::MembershipTypeIndividual`

## Testing
<!--
- Explain how you tested the changes.
- Mention any relevant test cases or manual steps.
-->
## Related Issues
- https://tipit.avaza.com/task#task=3848895

## Notes
This PR is related with this other PR: https://github.com/OpenStackweb/osf-website/pull/683