### PR TITLE
Feature | Add oidc/session/whoami endpoint

### DIFF
--- a/openstackid/_config/routes.yml
+++ b/openstackid/_config/routes.yml
@@ -4,4 +4,5 @@ Name: openstackidroutes
 Director:
   rules:
     'OpenStackIdAuthenticator': 'OpenStackIdAuthenticator'
+    'oidc/session/whoami': 'OIDCSessionWhoAmIApi'
 

--- a/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
+++ b/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
@@ -104,7 +104,7 @@ final class OIDCSessionWhoAmIApi extends AbstractRestfulJsonApi
 	private function validateRequestData(SS_HTTPRequest $request)
 	{
 		// Check if request method is POST
-		if (!$request->isPOST()) {
+		if (!$request->isGET()) {
 			return $this->methodNotAllowed();
 		}
 
@@ -136,8 +136,8 @@ final class OIDCSessionWhoAmIApi extends AbstractRestfulJsonApi
 	protected function methodNotAllowed()
 	{
 		return parent::methodNotAllowed()
-			->setBody(json_encode("Only POST requests are allowed"))
-			->addHeader('Allow', 'POST');
+			->setBody(json_encode("Only GET requests are allowed"))
+			->addHeader('Allow', 'GET');
 	}
 
 

--- a/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
+++ b/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
@@ -76,7 +76,8 @@ final class OIDCSessionWhoAmIApi extends AbstractRestfulJsonApi
 				return $response;
 			}
 
-			$member = Member::currentUser();
+			$memberID = Session::get('loggedInAs');
+			$member = $memberID ? Member::get()->filter(['ID' => $memberID])->first() : null;
 
 			if (!$member) {
 				$response = $this->notFound('No authenticated user found');
@@ -122,7 +123,7 @@ final class OIDCSessionWhoAmIApi extends AbstractRestfulJsonApi
 		}
 
 		// Check X-CSRF-Token header value
-		if ($csrfToken !== $this->getSecurityToken()) {
+		if ($csrfToken !== Session::get('SecurityID')) {
 			return $this->badRequest('X-CSRF-Token header is invalid');
 		}
 

--- a/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
+++ b/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
@@ -76,9 +76,7 @@ final class OIDCSessionWhoAmIApi extends AbstractRestfulJsonApi
 				return $response;
 			}
 
-			$memberID = Session::get('loggedInAs');
-			$member = $memberID ? Member::get()->filter(['ID' => $memberID])->first() : null;
-
+			$member = Member::currentUser();
 			if (!$member) {
 				$response = $this->notFound('No authenticated user found');
 			} else {

--- a/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
+++ b/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
@@ -76,24 +76,17 @@ final class OIDCSessionWhoAmIApi extends AbstractRestfulJsonApi
 				return $response;
 			}
 
-      $member = Member::currentUser();
+			$member = Member::currentUser();
 
-      $response = new SS_HTTPResponse();
-      $response->addHeader('Content-Type', 'application/json');
-
-      if (!$member) {
-        $response->setStatusCode(404);
-        $response->setBody(json_encode(['message' => 'No authenticated user found']));
-      }
-      else
-      {
-        $response->setStatusCode(200);
-        $response->setBody(json_encode([
-          'user_id' => $member->ID,
-          'email' => $member->Email,
-        ]));
-      }
-      return $response;
+			if (!$member) {
+				$response = $this->notFound('No authenticated user found');
+			} else {
+				$response = $this->ok([
+					'user_id' => $member->ID,
+					'email' => $member->Email,
+				]);
+			}
+			return $response;
 
 		} catch (EntityValidationException $ex1) {
 			SS_Log::log($ex1, SS_Log::WARN);
@@ -146,6 +139,21 @@ final class OIDCSessionWhoAmIApi extends AbstractRestfulJsonApi
 		return parent::methodNotAllowed()
 			->setBody(json_encode("Only POST requests are allowed"))
 			->addHeader('Allow', 'POST');
+	}
+
+
+	/**
+	 * Return method bad request response
+	 * @param string $error
+	 * @return SS_HTTPResponse
+	 */
+	protected function badRequest(string $error)
+	{
+		$response = new SS_HTTPResponse();
+		$response->setStatusCode(400);
+		$response->addHeader('Content-Type', 'application/json');
+		$response->setBody(json_encode(["error" => $error]));
+		return $response;
 	}
 
 	protected function getSecurityToken()

--- a/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
+++ b/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
@@ -26,7 +26,7 @@ final class OIDCSessionWhoAmIApi extends AbstractRestfulJsonApi
 	 * @var array
 	 */
 	private static $url_handlers = [
-		'POST ' => 'index',
+		'GET ' => 'index',
 	];
 
 	/**

--- a/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
+++ b/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
@@ -108,12 +108,6 @@ final class OIDCSessionWhoAmIApi extends AbstractRestfulJsonApi
 			return $this->methodNotAllowed();
 		}
 
-		// Check Content-Type header
-		$contentType = $request->getHeader('Content-Type');
-		if (strpos($contentType, 'application/json') === false) {
-			return $this->validationError(['Content-Type must be application/json']);
-		}
-
 		// Check X-CSRF-Token header
 		$csrfToken = $request->getHeader('X-CSRF-Token') ?: $request->getHeader('X-Csrf-Token');
 		if (empty($csrfToken)) {

--- a/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
+++ b/openstackid/code/interfaces/restfull_api/OIDCSessionWhoAmIApi.php
@@ -1,0 +1,155 @@
+<?php
+
+
+/**
+ * Copyright 2025 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+/**
+ * Class OIDCSessionWhoAmIApi
+ * Handles OIDC session whoami requests
+ */
+final class OIDCSessionWhoAmIApi extends AbstractRestfulJsonApi
+{
+	private static $api_prefix = 'oidc/session/whoami';
+
+	/**
+	 * @var array
+	 */
+	private static $url_handlers = [
+		'POST ' => 'index',
+	];
+
+	/**
+	 * @var array
+	 */
+	private static $allowed_actions = [
+		'index',
+	];
+
+	/**
+	 * @return bool
+	 */
+	protected function isApiCall()
+	{
+		$request = $this->getRequest();
+		if (is_null($request))
+			return false;
+		return true;
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function authorize()
+	{
+		return true;
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function authenticate()
+	{
+		return true;
+	}
+
+	/**
+	 * Bootstrap OIDC session
+	 * @param SS_HTTPRequest $request
+	 * @return SS_HTTPResponse
+	 */
+	public function index(SS_HTTPRequest $request)
+	{
+		try {
+			$response = $this->validateRequestData($request);
+			if ($response instanceof SS_HTTPResponse) {
+				return $response;
+			}
+
+      $member = Member::currentUser();
+
+      $response = new SS_HTTPResponse();
+      $response->addHeader('Content-Type', 'application/json');
+
+      if (!$member) {
+        $response->setStatusCode(404);
+        $response->setBody(json_encode(['message' => 'No authenticated user found']));
+      }
+      else
+      {
+        $response->setStatusCode(200);
+        $response->setBody(json_encode([
+          'user_id' => $member->ID,
+          'email' => $member->Email,
+        ]));
+      }
+      return $response;
+
+		} catch (EntityValidationException $ex1) {
+			SS_Log::log($ex1, SS_Log::WARN);
+			return $this->validationError($ex1->getMessages());
+		} catch (Exception $ex) {
+			SS_Log::log($ex, SS_Log::ERR);
+			return $this->serverError();
+		}
+	}
+
+	/**
+	 * Validate request data
+	 * @param SS_HTTPRequest $request
+	 * @return bool|SS_HTTPResponse
+	 */
+	private function validateRequestData(SS_HTTPRequest $request)
+	{
+		// Check if request method is POST
+		if (!$request->isPOST()) {
+			return $this->methodNotAllowed();
+		}
+
+		// Check Content-Type header
+		$contentType = $request->getHeader('Content-Type');
+		if (strpos($contentType, 'application/json') === false) {
+			return $this->validationError(['Content-Type must be application/json']);
+		}
+
+		// Check X-CSRF-Token header
+		$csrfToken = $request->getHeader('X-CSRF-Token') ?: $request->getHeader('X-Csrf-Token');
+		if (empty($csrfToken)) {
+			return $this->validationError(['X-CSRF-Token header is required', "headers" => $request->getHeaders()]);
+		}
+
+		// Check X-CSRF-Token header value
+		if ($csrfToken !== $this->getSecurityToken()) {
+			return $this->badRequest('X-CSRF-Token header is invalid');
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return method not allowed response
+	 * @param string $message
+	 * @return SS_HTTPResponse
+	 */
+	protected function methodNotAllowed()
+	{
+		return parent::methodNotAllowed()
+			->setBody(json_encode("Only POST requests are allowed"))
+			->addHeader('Allow', 'POST');
+	}
+
+	protected function getSecurityToken()
+	{
+		return SecurityToken::inst() ? SecurityToken::inst()->getValue() : null;
+	}
+}


### PR DESCRIPTION
# Summary

## Task request:
> ref: https://tipit.avaza.com/project/view/188886#!tab=task-pane&groupby=ProjectSection&view=vertical&task=3867899&stafilter=NotComplete&fileview=grid
> depends on https://tipit.avaza.com/task#task=3862033
> 
> **UC**
> 
> if user is logged first at [legacy.openstack.org](https://legacy.openstack.org/) and then navigates back to any page of marketing site ( GS counterpart ) user is logged off we need to be able to autologin user at marketing site if they are already logged at legacy ( silverstripe)
> 
> 1. create lite weight endpoint called GET oidc/session/whoiam
> 
> endpoint should check silverstripe session and return 200 OK with email and user id as body ( JSON ) or 404 if not logged
> 
> endpoint should support X-CSRF-Token 
> 
> 2. marketing site , if user is not logged ( check reducer) should query that endpoint on page load and if returns 200 should trigger login flow with email as a hint
> 
> **dev notes**
> 
> **repos**
> 
> https://github.com/OpenStackweb/openstack-org
> 
> https://github.com/OpenStackweb/marketing-site


## Changes
- Add oidc/session/whoami endpoint with the requested functionality,

## Testing
Using CURL:

```bash
curl 'http://localhost:9000/oidc/session/whoami' \
  -X 'POST' \
  -H 'Accept: */*' \
  -H 'Accept-Language: es-419,es;q=0.9,en-US;q=0.8,en;q=0.7,es-ES;q=0.6,en-GB;q=0.5,es-AR;q=0.4,es-MX;q=0.3' \
  -H 'Connection: keep-alive' \
  -H 'Content-Length: 0' \
  -b '_gcl_au=1.1.1303657569.1755799845; _ga=GA1.1.430326254.1755799845; _fbp=fb.0.1755799845466.486871936358385000; klaro=%7B%22google-tag-manager%22%3Atrue%2C%22google-analytics%22%3Atrue%7D; _ga_YQSD5D1F6S=GS2.1.s1755808292$o2$g0$t1755808292$j60$l0$h0; GetTextLocale=en_US; _uetvid=cf8184c077a411f09a80b34c59e34abf; _gid=GA1.1.161397762.1757339417; _uetsid=503875308cbb11f09d772b5b47162636; user_date=2025-9-11; idToken=eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwczovL3Rlc3RvcGVuc3RhY2tpZC5vcGVuc3RhY2sub3JnIiwic3ViIjoiMTE0MjY2IiwiYXVkIjoiaDF3VlRWbTc1VEpTbVZjS3RWWHRZZXFjLU5LcU1IODYub3BlbnN0YWNrLmNsaWVudCIsImlhdCI6MTc1NzYxNDUyNCwiZXhwIjoxNzU3NjE4MTI0LCJqdGkiOiJLQlpJNW5CSGpvd3Z4SlIzeXhqbVFLTHU3TzZiVzlzQUZTOHU4SDZsTW1rWmZTOTNaSzVqa3lwTEFZeElYYU03eWVITGdLekxtZUROdVRwbXRTMGszZyIsIm5hbWUiOiJNYXRpYXMgUGVycm9uZSIsImdpdmVuX25hbWUiOiJNYXRpYXMiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJtYXRpYXMucGVycm9uZSIsImZhbWlseV9uYW1lIjoiUGVycm9uZSIsIm5pY2tuYW1lIjoibWF0aWFzLnBlcnJvbmUiLCJwaWN0dXJlIjoiaHR0cHM6Ly93d3cuZ3JhdmF0YXIuY29tL2F2YXRhci8wYWQ3NDRhZTNjZjIzMDc0OTRmMDQ1YWUwZmJjOTEwMCIsImJpcnRoZGF0ZSI6IjE5NzgtMDUtMjEgMDA6MDA6MDAiLCJnZW5kZXIiOiJNYWxlIiwiZ2VuZGVyX3NwZWNpZnkiOiIiLCJsb2NhbGUiOiIiLCJiaW8iOiIiLCJzdGF0ZW1lbnRfb2ZfaW50ZXJlc3QiOiIiLCJpcmMiOiIiLCJnaXRodWJfdXNlciI6Im1hdGlhc3BlcnJvbmUtZXhvIiwid2VjaGF0X3VzZXIiOiIiLCJ0d2l0dGVyX25hbWUiOiIiLCJsaW5rZWRfaW5fcHJvZmlsZSI6IiIsImNvbXBhbnkiOiIiLCJqb2JfdGl0bGUiOiIiLCJwdWJsaWNfcHJvZmlsZV9zaG93X3Bob3RvIjpmYWxzZSwicHVibGljX3Byb2ZpbGVfc2hvd19iaW8iOnRydWUsInB1YmxpY19wcm9maWxlX3Nob3dfc29jaWFsX21lZGlhX2luZm8iOmZhbHNlLCJwdWJsaWNfcHJvZmlsZV9zaG93X2Z1bGxuYW1lIjpmYWxzZSwicHVibGljX3Byb2ZpbGVfYWxsb3dfY2hhdF93aXRoX21lIjpmYWxzZSwicHVibGljX3Byb2ZpbGVfc2hvd190ZWxlcGhvbmVfbnVtYmVyIjpmYWxzZSwiZ3JvdXBzIjpbeyJpZCI6MSwiY3JlYXRlZF9hdCI6MTU2NTExMTMzMCwidXBkYXRlZF9hdCI6MTU2NTExMTMzMCwibmFtZSI6InN1cGVyIGFkbWlucyIsInNsdWciOiJzdXBlci1hZG1pbnMiLCJhY3RpdmUiOnRydWUsImRlZmF1bHQiOmZhbHNlfV0sImFkZHJlc3MiOnsiY291bnRyeSI6IkFSIiwic3RyZWV0X2FkZHJlc3MiOiIgIiwiYWRkcmVzczEiOiIiLCJhZGRyZXNzMiI6IiIsInBvc3RhbF9jb2RlIjoiIiwicmVnaW9uIjoiIiwibG9jYWxpdHkiOiIiLCJmb3JtYXR0ZWQiOiIgLCBBUiJ9LCJlbWFpbCI6Im1hdGlhcy5wZXJyb25lQGV4b21pbmRzZXQuY28iLCJzZWNvbmRfZW1haWwiOiJoZWxsb0BtYXRpYXNwZXJyb25lLmNvbSIsInRoaXJkX2VtYWlsIjoiIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsInB1YmxpY19wcm9maWxlX3Nob3dfZW1haWwiOmZhbHNlLCJub25jZSI6IndzbnRiWHk1VTdkb2Rad2sifQ.; PHPSESSID=8tvsdsdb4ehdel3n12b0kj1rsb; _ga_LQC4JWNC08=GS2.1.s1757618594$o24$g1$t1757624949$j52$l0$h0' \
  -H 'Origin: http://localhost:9000/' \
  -H 'Referer: http://localhost:9000/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0' \
  -H 'content-type: application/json' \
  -H 'sec-ch-ua: "Chromium";v="140", "Not=A?Brand";v="24", "Microsoft Edge";v="140"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "Windows"'
```

Using fetch:

```javascript
function testFn() {
    const myHeaders = new Headers();
    myHeaders.append("Content-Type", "application/json");
    myHeaders.append("X-CSRF-Token", "d8f86ee0975b3fc664f5c5409165eec7206cb129");
    
  const host = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '');
  const myRequest = new Request(`${host}/oidc/session/whoami`, {
      method: "POST",
      body: '',
      headers: myHeaders,
    });
    
    return fetch(myRequest);
}
testFn().then(console.log)

```
